### PR TITLE
Change some columns to factors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: epanetReader
 Type: Package
 Title: Read Epanet Files into R
-Version: 0.3.0-0003
-Date: 2016-01-08
+Version: 0.3.0-0005
+Date: 2016-02-02
 Author: Bradley J. Eck
 Maintainer: Bradley Eck <brad@bradeck.net>
 Depends:

--- a/R/epanet.inp-s3.r
+++ b/R/epanet.inp-s3.r
@@ -26,7 +26,9 @@
 #' sections of the .inp file.  Sections of the .inp file that are implemented 
 #' appear in the Value section.
 #' 
-#' ID fields are stored as characters not factors or integers.
+#' Fields for node or link ID are stored as characters not factors or integers.
+#' However, some fields are stored as factors
+#' to allow more informative summaries. Examples include valve type and pipe status.  
 #'        
 #' Sections that are absent from the .inp file are NULL in the list.
 #' 

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -671,6 +671,7 @@ STATUS <- function( allLines ){
 		df$ID <- as.character(df$ID)
 		
 		names(df)[2] <- "Status"
+        df$Status <- as.factor(df$Status)
 
 		return(df)
 	}

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -309,6 +309,9 @@ PUMPS <- function( allLines ){
 		# just keep the four cols we like
 		pmp <- df[,c("ID", "Node1", "Node2", "Parameters")]
 		
+		# store the parameters as a factor 
+		pmp$Parameters <- as.factor(pmp$Parameters)
+		
 		return(pmp)
 	}
 }

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -344,6 +344,7 @@ VALVES <-function( allLines){
     # name further cols 
     names(df)[4:7] <- c("Diameter", "Type", "Setting", "MinorLoss")
     df$ID <- as.character(df$ID)
+	df$Type <- as.factor(df$Type)
   
     return(df)
   }

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -187,7 +187,7 @@ RESERVOIRS <- function(allLines){
 		if( dim(df)[2] > 2){
 			# there is a pattern column
 			names(df)[3] <- "Pattern"
-			df$Pattern <- as.character(df$Pattern)
+			df$Pattern <- as.factor(df$Pattern)
 		} else {
 			# add it anyway and fill w NA
 			df$Pattern <- NA

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -228,7 +228,7 @@ TANKS <- function( allLines ){
 		
 		if( dim(df)[2]>7 ){
 			names(df)[8] <- "VolCurve"
-			df$VolCurve <- as.character(df$VolCurve)
+			df$VolCurve <- as.factor(df$VolCurve)
 		} else {
 			df$VolCurve <- NA
 		}

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -371,7 +371,7 @@ DEMANDS <-function( allLines){
     
     #convert id and pattern field to character
     df$Node <- as.character(df$Node) 
-	df$Pattern <- as.character(df$Pattern)
+	df$Pattern <- as.factor(df$Pattern)
 
     return(df)
   }

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -270,7 +270,7 @@ PIPES <- function( allLines ){
 		
 		if( dim(df)[2]>7 ){
 			names(df)[8] <- "Status"
-			df$Status <- as.character(df$Status)
+			df$Status <- as.factor(df$Status)
 		} else {
 			df$Status<- NA
 		}

--- a/R/inpFuncs.r
+++ b/R/inpFuncs.r
@@ -153,7 +153,7 @@ JUNCTIONS <- function( allLines){
 		if( dim(df)[2] > 3){
 			# there is a pattern column
 			names(df)[4] <- "Pattern"
-			df$Pattern <- as.character(df$Pattern)
+			df$Pattern <- as.factor(df$Pattern)
 		} else {
 			# add it anyway and fill w NA
 			df$Pattern <- NA

--- a/tests/for-various-tests.inp
+++ b/tests/for-various-tests.inp
@@ -6,5 +6,10 @@ It's not intended to run.
 ;ID              	Elevation   	InitLevel   	MinLevel    	MaxLevel    	Diameter    	MinVol      	VolCurve
  A               	123         	11          	10          	20          	50.5        	0           	vc1   ;
 
+[RESERVOIRS]
+;ID              	Head        	Pattern         
+ C               	321         	respat                	;
+ 
+ 
 [END]
 

--- a/tests/for-various-tests.inp
+++ b/tests/for-various-tests.inp
@@ -1,0 +1,10 @@
+[TITLE]
+This file is for testing parts of the epanetReader package.
+It's not intended to run.
+
+[TANKS]
+;ID              	Elevation   	InitLevel   	MinLevel    	MaxLevel    	Diameter    	MinVol      	VolCurve
+ A               	123         	11          	10          	20          	50.5        	0           	vc1   ;
+
+[END]
+

--- a/tests/test_epanet.inp-s3.r
+++ b/tests/test_epanet.inp-s3.r
@@ -40,7 +40,7 @@ test_that("read Net3.inp",{
 			Net3 <- suppressWarnings( read.inp("Net3.inp"))
 			
 			expect_false( is.null(Net3$Status))
-			expect_equal(Net3$Status$Status[1], 'Closed')
+			expect_true(Net3$Status$Status[1] == 'Closed')
 		})
 
 context("summary.epanet.inp s3 object") 

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -348,3 +348,9 @@ test_that("[Pipes] status is factor",{
 			pipe <- PIPES(readLines("Net3.inp"))
 			expect_true(class(pipe$Status) == 'factor')
 		})
+
+test_that("[Pumps] keyword is factor",{
+			
+			pmp <- PUMPS(readLines("Net3.inp"))
+			expect_true(class(pmp$Parameters) == 'factor')
+		})

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -215,7 +215,7 @@ test_that("[STATUS]  reads ok" ,{
 			
 	stat <- STATUS( readLines("Net3.inp"))
 	expect_that( stat[1,1], equals('10') )
-	expect_that( stat[1,2], equals("Closed"))
+	expect_true( stat[1,2] =="Closed")
 			
 			
 		})
@@ -359,4 +359,10 @@ test_that("[Valves] type is factor",{
 			
 			vlv <- VALVES(readLines("oneprv.inp"))
 			expect_true(class(vlv$Type) == 'factor')
+		})
+
+test_that("[Status] Status is factor",{
+			
+			stat <- STATUS(readLines("Net3.inp"))
+			expect_true(class(stat$Status) == 'factor')
 		})

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -354,3 +354,9 @@ test_that("[Pumps] keyword is factor",{
 			pmp <- PUMPS(readLines("Net3.inp"))
 			expect_true(class(pmp$Parameters) == 'factor')
 		})
+
+test_that("[Valves] type is factor",{
+			
+			vlv <- VALVES(readLines("oneprv.inp"))
+			expect_true(class(vlv$Type) == 'factor')
+		})

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -366,3 +366,10 @@ test_that("[Status] Status is factor",{
 			stat <- STATUS(readLines("Net3.inp"))
 			expect_true(class(stat$Status) == 'factor')
 		})
+
+test_that("[Demands] Pattern is factor",{
+		
+			dmd <- DEMANDS(readLines("oneprv.inp"))
+			expect_true(class(dmd$Pattern) == 'factor')
+			
+		})

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -29,7 +29,7 @@ test_that("Net1 JUNCTIONs table",
 test_that("Net2 JUNCTIONS table",
          {
             jt <- JUNCTIONS(readLines("Net2.inp"))
-            expect_that(jt$Pattern[1], equals("2"))
+            expect_true( jt$Pattern[1] == 2 ) 
          })
 
 #test_that("poormond JUNCTIONS table",
@@ -321,4 +321,11 @@ test_that(" junction IDs are char",{
 			
 			junc <- JUNCTIONS(readLines("Net1.inp"))
 		    expect_true( class(junc$ID) == "character")	
+		})
+
+context("some non-ID columns in inp sections are factors")
+test_that("[Junctions] Pattern is factor",{
+			
+			junc <- JUNCTIONS(readLines("Net2.inp"))
+			expect_true( class(junc$Pattern) == 'factor')
 		})

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -343,3 +343,8 @@ test_that("[Reservoirs] Pattern is factor",{
 			expect_true( class(res$Pattern) == 'factor')
 		})
 
+test_that("[Pipes] status is factor",{
+			
+			pipe <- PIPES(readLines("Net3.inp"))
+			expect_true(class(pipe$Status) == 'factor')
+		})

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -336,3 +336,10 @@ test_that("[Tanks] Curve ID is factor",{
 			expect_true( class(tank$VolCurve) == 'factor')
 			
 		})
+
+test_that("[Reservoirs] Pattern is factor",{
+			
+			res <- RESERVOIRS(readLines("for-various-tests.inp"))
+			expect_true( class(res$Pattern) == 'factor')
+		})
+

--- a/tests/test_inpFuncs.r
+++ b/tests/test_inpFuncs.r
@@ -329,3 +329,10 @@ test_that("[Junctions] Pattern is factor",{
 			junc <- JUNCTIONS(readLines("Net2.inp"))
 			expect_true( class(junc$Pattern) == 'factor')
 		})
+
+test_that("[Tanks] Curve ID is factor",{
+			
+			tank <- TANKS(readLines("for-various-tests.inp"))
+			expect_true( class(tank$VolCurve) == 'factor')
+			
+		})


### PR DESCRIPTION
Columns for several sections of .inp files were changed from character to factor data type. Changes were made in the tables: Junctions$Pattern, Tanks$VolCurve, Reservoirs$Pattern, Pipes$Status, Pumps$Paramters, Valves$Type Status$Status, and Demand$Pattern.  These changes enable more informative summaries. Now summary(Net1$Pipes) will show that all pipes have a Status of Open.  Before the status column was character and so the summary didn't provide this info.   closes #2 
