### PR TITLE
Speed reading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ Temporary Items
 *.prefs
 .project
 
+tests/benchmarks.r

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,3 @@ Temporary Items
 *.prefs
 .project
 
-tests/benchmarks.r

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,14 +1,16 @@
 Package: epanetReader
 Type: Package
 Title: Read Epanet Files into R
-Version: 0.3.1-0001
-Date: 2016-05-12
+Version: 0.3.1-0005
+Date: 2016-07-28
 Author: Bradley J. Eck
 Maintainer: Bradley Eck <brad@bradeck.net>
 Depends:
     R (>= 3.0.0),
     graphics,
     utils
+Suggests:
+	Kmisc (>= 0.5.0)
 Description: Reads water network simulation data in Epanet's text-based
     '.inp' and '.rpt' formats into R. Also reads results from Epanet-msx.
     Provides basic summary information and plots. 

--- a/R/epanet.inp-s3.r
+++ b/R/epanet.inp-s3.r
@@ -86,7 +86,7 @@ read.inp <- function (file ){
 
 epanet.inp <- function( file ){
 	
-	allLines <- readLines( file )
+	allLines <- read_lines_wrapper( file )
   
   # read in all the sections  
   titl <- TITLE( allLines )

--- a/R/epanet.rpt-s3.r
+++ b/R/epanet.rpt-s3.r
@@ -62,7 +62,7 @@ read.rpt <- function( file ){
 
 epanet.rpt <- function( file){
   # read all the lines in the file 
-  allLines <- readLines(file)
+  allLines <- read_lines_wrapper(file)
   checkRptFile( allLines ) 
 
   lengthOfAllLines <- length( allLines)

--- a/R/epanetmsx.rpt-s3.r
+++ b/R/epanetmsx.rpt-s3.r
@@ -49,7 +49,7 @@ epanetmsx.rpt <- function( file ) {
 # this based heavily on the epanet.rpt function
 	
   # read all the lines in the file 
-  allLines <- readLines(file)
+  allLines <- read_lines_wrapper(file)
   #checkRptFile( allLines ) 
 
   title <- getTitle( allLines) 

--- a/R/text_file_reader.r
+++ b/R/text_file_reader.r
@@ -5,36 +5,35 @@
 #  Author: Bradley J Eck
 #
 #************************************
-#' Read char lines  
+#' Read lines wrapper   
 #' 
-#' Read lines of characters from a file via 
-#' the readChar function. 
-#' 
-#' @export
+#' Wrapper function for different implementations of
+#' readlines functions  
+#'
+#' @export  
 #' @param file the name of the file to read 
 #' @return character vector where each entry corresponds to 
-#' a line in the file.  #'
+#' a line in the file.  
 #' @details
-#' Checks for windows and unix line endings. 
-#' Testing showed this took about half the time of base::readLines()  
-
-read_char_lines <- function( file ){
+#' calls Kmisc::readlines if available and base::readLines otherwise 
+read_lines_wrapper <- function( file ){
 	
 	size <- file.info(file)$size
-	val <- readChar( file, size, TRUE)
+	size_MB <- size / 1e6
 	
-	has_windows_ending <- grepl("\r\n", val)
-	has_unix_ending <- grepl("\n", val)
-	if( has_windows_ending ) { 
-		sp <-   strsplit(val, "\r\n")
-		cv <- sp[[1]]
-	} else if( has_unix_ending ){
-		# assume unix ending
-		sp <-  strsplit(val, "\n" ) 
-		cv <- sp[[1]]
+	if( requireNamespace("Kmisc", quietly = TRUE)){
+		
+		allLines <- Kmisc::readlines(file)
+		
 	} else {
-		# didn't work for some reason so default to readLines
-		cv <- readLines( file )
+		
+		if( size_MB > 100){
+			warning("Consider installing package Kmisc to speed up file reading")
+		}
+		
+		allLines <- readLines(file)
+		
 	}
-	return (cv)
+	
+	return (allLines)
 }

--- a/R/text_file_reader.r
+++ b/R/text_file_reader.r
@@ -1,0 +1,40 @@
+#************************************
+#
+#  (C) Copyright IBM Corp. 2016
+#
+#  Author: Bradley J Eck
+#
+#************************************
+#' Read char lines  
+#' 
+#' Read lines of characters from a file via 
+#' the readChar function. 
+#' 
+#' @export
+#' @param file the name of the file to read 
+#' @return character vector where each entry corresponds to 
+#' a line in the file.  #'
+#' @details
+#' Checks for windows and unix line endings. 
+#' Testing showed this took about half the time of base::readLines()  
+
+read_char_lines <- function( file ){
+	
+	size <- file.info(file)$size
+	val <- readChar( file, size, TRUE)
+	
+	has_windows_ending <- grepl("\r\n", val)
+	has_unix_ending <- grepl("\n", val)
+	if( has_windows_ending ) { 
+		sp <-   strsplit(val, "\r\n")
+		cv <- sp[[1]]
+	} else if( has_unix_ending ){
+		# assume unix ending
+		sp <-  strsplit(val, "\n" ) 
+		cv <- sp[[1]]
+	} else {
+		# didn't work for some reason so default to readLines
+		cv <- readLines( file )
+	}
+	return (cv)
+}

--- a/tests/benchmarks.r
+++ b/tests/benchmarks.r
@@ -7,29 +7,43 @@
 library(microbenchmark)
 context("benchmark file reading   ")
 
-source("../R/text_file_reader.r")
+## bje implementation for test purposes
+read_char_lines <- function( file ){
+	
+	size <- file.info(file)$size
+	val <- readChar( file, size, TRUE)
+	
+	has_windows_ending <- grepl("\r\n", val)
+	has_unix_ending <- grepl("\n", val)
+	if( has_windows_ending ) { 
+		sp <-   strsplit(val, "\r\n")
+		cv <- sp[[1]]
+	} else if( has_unix_ending ){
+		# assume unix ending
+		sp <-  strsplit(val, "\n" ) 
+		cv <- sp[[1]]
+	} else {
+		# didn't work for some reason so default to readLines
+		cv <- readLines( file )
+	}
+	return (cv)
+}
 
-test_that("benchmark reading Net2.rpt",{
-			
-		x <- "Net2.rpt"
-			
-		mb <- microbenchmark(
-				baseReadLines = readLines(x),
-				viaReadChar = read_char_lines(x), 
-				
-				times = 10
-		) 
-		
-		print(mb)	
-		})
-
-test_that("benchmark etmnt.rpt",{
+test_that("benchmark file reading",{
+		library(Kmisc)
+		library(readr)
 			
 		x <- file.path(R.home("doc"), "COPYING")
 		
+		
+		
 		mb <- microbenchmark(
 				baseReadLines = readLines(x),
-		        Kmisc_readlines = readlines(x)
+				bje_read_char_lines = read_char_lines(x),
+		        Kmisc_readlines = Kmisc::readlines(x),
+		        readr_read_lines = readr::read_lines(x),
+				
+				times = 50
 		) 
 		
 		print(mb)	

--- a/tests/benchmarks.r
+++ b/tests/benchmarks.r
@@ -25,15 +25,15 @@ test_that("benchmark reading Net2.rpt",{
 
 test_that("benchmark etmnt.rpt",{
 			
-		x <- "../../../networks/et/etmnt.rpt"
-		readLines(x)	
+		x <- file.path(R.home("doc"), "COPYING")
+		
 		mb <- microbenchmark(
 				baseReadLines = readLines(x),
-				viaReadChar = read_char_lines(x), 
-				
-				times = 10
+		        Kmisc_readlines = readlines(x)
 		) 
 		
 		print(mb)	
 			
 		})
+
+

--- a/tests/benchmarks.r
+++ b/tests/benchmarks.r
@@ -23,4 +23,17 @@ test_that("benchmark reading Net2.rpt",{
 		print(mb)	
 		})
 
-
+test_that("benchmark etmnt.rpt",{
+			
+		x <- "../../../networks/et/etmnt.rpt"
+		readLines(x)	
+		mb <- microbenchmark(
+				baseReadLines = readLines(x),
+				viaReadChar = read_char_lines(x), 
+				
+				times = 10
+		) 
+		
+		print(mb)	
+			
+		})

--- a/tests/benchmarks.r
+++ b/tests/benchmarks.r
@@ -1,0 +1,26 @@
+
+# document some benchmarking work
+# this file is written to call with testthat
+# but is not part of the default test suite 
+# as the file name does not begin with test_
+
+library(microbenchmark)
+context("benchmark file reading   ")
+
+source("../R/text_file_reader.r")
+
+test_that("benchmark reading Net2.rpt",{
+			
+		x <- "Net2.rpt"
+			
+		mb <- microbenchmark(
+				baseReadLines = readLines(x),
+				viaReadChar = read_char_lines(x), 
+				
+				times = 10
+		) 
+		
+		print(mb)	
+		})
+
+

--- a/tests/test_epanet.inp-s3.r
+++ b/tests/test_epanet.inp-s3.r
@@ -11,6 +11,7 @@
 source("../R/epanet.inp-s3.r")
 source("../R/inpFuncs.r")
 source("../R/expandedLinkTable-s3.r")
+source("../R/text_file_reader.r")
 
 
    

--- a/tests/test_text_file_reader.r
+++ b/tests/test_text_file_reader.r
@@ -12,9 +12,9 @@ context("text file reader")
 test_that("same result as readLines",{
 			
 		x <- "Net1.inp"	
-		rl	<- readLines( x)
-		rcl <- read_char_lines(x)
-		pass <- identical( rl, rcl)	
+		rl	<- readLines(x)
+		rlw <- read_lines_wrapper(x)
+		pass <- identical( rl, rlw)	
 		expect_true(pass)
 		})
 
@@ -22,9 +22,7 @@ test_that(" Net2.rpt same result as readLines",{
 			
 		x <- "Net2.rpt"	
 		rl	<- readLines( x)
-		rcl <- read_char_lines(x)
-		pass <- identical( rl, rcl)	
+		rlw <- read_lines_wrapper(x)
+		pass <- identical( rl, rlw)	
 		expect_true(pass)
 		})
-
-# profile 

--- a/tests/test_text_file_reader.r
+++ b/tests/test_text_file_reader.r
@@ -1,0 +1,30 @@
+#************************************
+#
+#  (C) Copyright IBM Corp. 2016
+#
+#  Author: Bradley J Eck
+#
+#************************************
+
+source("../R/text_file_reader.r")
+context("text file reader")
+
+test_that("same result as readLines",{
+			
+		x <- "Net1.inp"	
+		rl	<- readLines( x)
+		rcl <- read_char_lines(x)
+		pass <- identical( rl, rcl)	
+		expect_true(pass)
+		})
+
+test_that(" Net2.rpt same result as readLines",{
+			
+		x <- "Net2.rpt"	
+		rl	<- readLines( x)
+		rcl <- read_char_lines(x)
+		pass <- identical( rl, rcl)	
+		expect_true(pass)
+		})
+
+# profile 


### PR DESCRIPTION
Speed up reading of large files by using the Kmisc readlines function if available.  Also added a benchmark to compare with readr read_lines.   Closes #20 
