### PR TITLE
Use data.table

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: epanetReader
 Type: Package
 Title: Read Epanet Files into R
-Version: 0.6.2
-Date: 2018-01-27
+Version: 0.7.0
+Date: 2018-05-09
 Author: Bradley J. Eck
 Maintainer: Bradley Eck <brad@bradeck.net>
 Depends:
@@ -12,7 +12,7 @@ Depends:
 Suggests:
     testthat,
     epanet2toolkit,
-    Kmisc (>= 0.5.0)
+    data.table (>=1.11.2)
 Description: Reads water network simulation data in 'Epanet' text-based
     '.inp' and '.rpt' formats into R. Also reads results from 'Epanet-msx'.
     Provides basic summary information and plots.  The README file has a 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Depends:
 Suggests:
     testthat,
     epanet2toolkit,
-    data.table (>=1.11.2)
+    data.table (>= 1.11.2)
 Description: Reads water network simulation data in 'Epanet' text-based
     '.inp' and '.rpt' formats into R. Also reads results from 'Epanet-msx'.
     Provides basic summary information and plots.  The README file has a 

--- a/R/text_file_reader.r
+++ b/R/text_file_reader.r
@@ -23,8 +23,8 @@ read_lines_wrapper <- function( file ){
 	
 	if( requireNamespace("data.table", quietly = TRUE)){
 		
-		allLines <- data.table::fread(file, sep=NULL,colClasses = "character",autostart=1,
-		                              header=F,select=1,fill=T,data.table=F)[,1]
+		allLines <- data.table::fread(file, sep=NULL,colClasses = "character", strip.white=F,
+		                              header=F,fill=T,data.table=F)[,1]
 
 		
 	} else {

--- a/R/text_file_reader.r
+++ b/R/text_file_reader.r
@@ -21,14 +21,16 @@ read_lines_wrapper <- function( file ){
 	size <- file.info(file)$size
 	size_MB <- size / 1e6
 	
-	if( requireNamespace("Kmisc", quietly = TRUE)){
+	if( requireNamespace("data.table", quietly = TRUE)){
 		
-		allLines <- Kmisc::readlines(file)
+		allLines <- data.table::fread(file, sep=NULL,colClasses = "character",autostart=1,
+		                              header=F,select=1,fill=T,data.table=F)[,1]
+
 		
 	} else {
 		
 		if( size_MB > 100){
-			warning("Consider installing package Kmisc to speed up file reading")
+			warning("Consider installing package data.table to speed up file reading")
 		}
 		
 		allLines <- readLines(file)

--- a/tests/testthat/benchmarks.r
+++ b/tests/testthat/benchmarks.r
@@ -30,12 +30,21 @@ read_char_lines <- function( file ){
 	return (cv)
 }
 
+dtreadlines <- function(file){
+
+ x <- fread(file,sep=NULL,data.table=F)
+# ,colClasses="character",autostart=1,header=F,select=1,fill=T,data.table=F)
+ x[,1]
+} 
+
 test_that("benchmark file reading",{
 		library(Kmisc)
 		library(readr)
+    library(data.table)
 			
 		x <- file.path(R.home("doc"), "COPYING")
 		
+		dtreadlines(x)
 		
 		
 		mb <- microbenchmark(
@@ -43,6 +52,7 @@ test_that("benchmark file reading",{
 				bje_read_char_lines = read_char_lines(x),
 		        Kmisc_readlines = Kmisc::readlines(x),
 		        readr_read_lines = readr::read_lines(x),
+                        data.table_read_lines = dtreadlines(x),
 				
 				times = 50
 		) 

--- a/tests/testthat/benchmarks.r
+++ b/tests/testthat/benchmarks.r
@@ -32,9 +32,8 @@ read_char_lines <- function( file ){
 
 dtreadlines <- function(file){
 
- x <- fread(file,sep=NULL,data.table=F)
-# ,colClasses="character",autostart=1,header=F,select=1,fill=T,data.table=F)
- x[,1]
+		allLines <- data.table::fread(file, sep=NULL,colClasses = "character", strip.white=F,
+		                              header=F,fill=T,data.table=F)[,1]
 } 
 
 test_that("benchmark file reading",{
@@ -62,3 +61,26 @@ test_that("benchmark file reading",{
 		})
 
 
+test_that("benchmark file reading",{
+		library(Kmisc)
+		library(readr)
+    library(data.table)
+			
+		x <- file.path("Net3-gui.rpt")
+		
+		dtreadlines(x)
+		
+		
+		mb <- microbenchmark(
+				baseReadLines = readLines(x),
+				bje_read_char_lines = read_char_lines(x),
+		        Kmisc_readlines = Kmisc::readlines(x),
+		        readr_read_lines = readr::read_lines(x),
+                        data.table_read_lines = dtreadlines(x),
+				
+				times = 50
+		) 
+		
+		print(mb)	
+			
+		})


### PR DESCRIPTION
Benchmarking results show that Kmisc::readlines is still the fastest way to read all the lines of a file.  As Kmisc is not currently on CRAN this switches to using data.table::fread.   readr::read_lines was about as fast for the tested files but has lots more dependencies. 

closes #48 